### PR TITLE
Add support for CommonJS/AMD, published to npm/spm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+test
+assets
+node_modules
+spm_modules
+coverage
+.DS_Store

--- a/.spmignore
+++ b/.spmignore
@@ -1,0 +1,6 @@
+test
+assets
+node_modules
+spm_modules
+coverage
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vivus",
   "version": "0.1.2",
   "description": "JavaScript library to make drawing animation on SVG",
-  "main": "index.js",
+  "main": "dist/vivus.js",
   "scripts": {
     "test": "karma"
   },
@@ -32,5 +32,8 @@
     "karma-chrome-launcher": "^0.1.4",
     "karma-coverage": "^0.2.6",
     "karma-jasmine": "~0.2.0"
+  },
+  "spm": {
+    "main": "dist/vivus.js"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -5,6 +5,8 @@ Demo available on http://maxwellito.github.io/vivus
 Vivus is a lightweight JavaScript class (with no dependencies) that allows you to animate SVGs, giving them the appearence of being drawn. There are a variety of different animations available, as well as the option to create a custom script to draw your SVG in whatever way you like.
 
 Available via Bower: `bower install vivus`
+or vis npm: `npm install vivus`
+or vis spm: `spm install vivus` [![](http://spmjs.io/badge/vivus)](http://spmjs.io/package/vivus)
 or via jsDelivr CDN: `//cdn.jsdelivr.net/vivus/0.1.2/vivus.min.js`
 
 ## Animations

--- a/src/_build.js
+++ b/src/_build.js
@@ -5,5 +5,19 @@
   //import("pathformer.js");
   //import("vivus.js");
 
-  window.Vivus = Vivus;
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define([], function() {
+      return Vivus;
+    });
+  } else if (typeof exports === 'object') {
+    // Node. Does not work with strict CommonJS, but
+    // only CommonJS-like environments that support module.exports,
+    // like Node.
+    module.exports = Vivus;
+  } else {
+    // Browser globals
+    window.Vivus = Vivus;
+  }
+
 }());


### PR DESCRIPTION
Make vivus a [UMD](JavaScript modules) JavaScript module, and publish vivus to [npm](https://npmjs.org)(node) and [spm](http://spmjs.io)(browser) for wider usage.

https://npmjs.com/package/vivus

http://spmjs.io/package/vivus

>  If you need ownership of vivus in npm and spm, I would like to add it to you guys.



