### PR TITLE
Support whitespace in Polyline and Polygon paths

### DIFF
--- a/src/pathformer.js
+++ b/src/pathformer.js
@@ -120,7 +120,7 @@ Pathformer.prototype.rectToPath = function (element) {
 Pathformer.prototype.polylineToPath = function (element) {
   var i, path;
   var newElement = {};
-  var points = element.points.split(' ');
+  var points = element.points.trim().split(' ');
   
   // Reformatting if points are defined without commas
   if (element.points.indexOf(',') === -1) {


### PR DESCRIPTION
In SVGs that have leading or trailing whitespace in a polygone or polyline points series 'blank' coordinates are being added in creating L and M directives in the resulting path without coordinates.

If when converting polygons and polylines to paths we trim leading and trailing whitespace we do not have this issue.

I have been testing out the library with a wide array of internet sources SVGs and attempting to make them animate in a reasonably uniform manner.

About 3% of them have leading or trailing whitespace in polyline or polygon paths that is seemingly to make the SVG markup easier to read in an authoring tool of some form.