### PR TITLE
Update jsDelivr link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ Available via:
 
  - [NPM](https://www.npmjs.com/package/vivus): `npm install vivus`
  - [Bower](http://bower.io/): `bower install vivus`
- - [jsDelivr CDN](http://www.jsdelivr.com/#!vivus): `//cdn.jsdelivr.net/vivus/latest/vivus.min.js`
+ - [jsDelivr CDN](http://www.jsdelivr.com/#!vivus): `//cdn.jsdelivr.net/npm/vivus@latest/dist/vivus.min.js`
  - [CDNJS CDN](https://cdnjs.com/libraries/vivus)
  - [WebJars](http://www.webjars.org/)
 


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the links now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/vivus.

Feel free to ping me if you have any questions regarding this change.