### PR TITLE
Edit grammatical error on the hero section

### DIFF
--- a/index.html
+++ b/index.html
@@ -241,7 +241,7 @@
 		<!-- Intro -->
 		<div class="content">
 			<h1>vivus<small>, bringing your SVGs to life</small></h1>
-			<p>Vivus is a lightweight JavaScript class (with no dependencies) that allows you to animate SVGs, giving them the appearence of being drawn. There are a variety of different animations available, as well as the option to create a custom script to draw your SVG in whatever way you like.</p>
+			<p>Vivus is a lightweight JavaScript class (with no dependencies) that allows you to animate SVGs, giving them the appearance of being drawn. There are a variety of different animations available, as well as the option to create a custom script to draw your SVG in whatever way you like.</p>
 			<p class="intro-links">
 				<a href="//github.com/maxwellito/vivus" class="button bigger">View on GitHub</a>
 			</p>


### PR DESCRIPTION
This change fixes the grammatical error "appearence" 
to "appearance" on the Hero section of the Home page of Vivus.